### PR TITLE
UserAdmin: set users as Regular, Inactive and Admin

### DIFF
--- a/src/Vluzrmos/SlackApi/Contracts/SlackUserAdmin.php
+++ b/src/Vluzrmos/SlackApi/Contracts/SlackUserAdmin.php
@@ -5,4 +5,7 @@ namespace Vluzrmos\SlackApi\Contracts;
 interface SlackUserAdmin
 {
     public function invite($email, $options = []);
+    public function setRegular($user);
+    public function setAdmin($user);
+    public function setInactive($user);
 }

--- a/src/Vluzrmos/SlackApi/Methods/UserAdmin.php
+++ b/src/Vluzrmos/SlackApi/Methods/UserAdmin.php
@@ -22,4 +22,46 @@ class UserAdmin extends SlackMethod implements SlackUserAdmin
             '_attempts' => 1,
         ], $options));
     }
+
+    /**
+     * Set a user account as inactive.
+     * @param string $user The user to set as inactive.
+     *
+     * @return array
+     */
+    public function setInactive($user = null){
+        return $this->method('setInactive', [
+            'user' => $user,
+            'set_active' => true,
+            '_attempts' => 1,
+        ]);
+    }
+
+    /**
+     * Set a user account as regular.
+     * @param string $user The user to set as regular.
+     *
+     * @return array
+     */
+    public function setRegular($user = null){
+        return $this->method('setRegular', [
+            'user' => $user,
+            'set_active' => true,
+            '_attempts' => 1,
+        ]);
+    }
+
+    /**
+     * Set a user account as admin.
+     * @param string $user The user to set as admin.
+     *
+     * @return array
+     */
+    public function setAdmin($user = null){
+        return $this->method('setAdmin', [
+            'user' => $user,
+            'set_active' => true,
+            '_attempts' => 1,
+        ]);
+    }
 }


### PR DESCRIPTION
This edit allows the API to call the (well hidden and undocumented) setInactive, setRegular and SetAdmin methods on the userAdmin api.
