### PR TITLE
Fix conversations.history limit parameter (relates to #34 & #35)

### DIFF
--- a/src/Vluzrmos/SlackApi/Contracts/SlackChannel.php
+++ b/src/Vluzrmos/SlackApi/Contracts/SlackChannel.php
@@ -7,7 +7,7 @@ interface SlackChannel
     public function archive($channel);
     public function unarchive($channel);
     public function create($name);
-    public function history($channel, $count = 100, $latest = null, $oldest = 0, $inclusive = 1);
+    public function history($channel, $limit = 100, $latest = null, $oldest = 0, $inclusive = 1);
     public function info($channel);
     public function invite($channel, $user);
     public function join($name);

--- a/src/Vluzrmos/SlackApi/Contracts/SlackInstantMessage.php
+++ b/src/Vluzrmos/SlackApi/Contracts/SlackInstantMessage.php
@@ -5,7 +5,7 @@ namespace Vluzrmos\SlackApi\Contracts;
 interface SlackInstantMessage
 {
     public function close($channel);
-    public function history($channel, $count = 100, $latest = null, $oldest = 0, $inclusive = 1);
+    public function history($channel, $limit = 100, $latest = null, $oldest = 0, $inclusive = 1);
     public function lists();
     public function all();
     public function mark($channel, $ts);

--- a/src/Vluzrmos/SlackApi/Methods/Channel.php
+++ b/src/Vluzrmos/SlackApi/Methods/Channel.php
@@ -39,16 +39,16 @@ class Channel extends SlackMethod implements SlackChannel
      * @see https://api.slack.com/methods/conversations.history
      *
      * @param string $channel Channel to fetch history for.
-     * @param int    $count Number of messages to return, between 1 and 1000.
+     * @param int    $limit Number of messages to return, between 1 and 1000.
      * @param string $latest End of time range of messages to include in results.
      * @param int    $oldest Start of time range of messages to include in results.
      * @param int    $inclusive Include messages with latest or oldest timestamp in results.
      *
      * @return array
      */
-    public function history($channel, $count = 100, $latest = null, $oldest = 0, $inclusive = 1)
+    public function history($channel, $limit = 100, $latest = null, $oldest = 0, $inclusive = 1)
     {
-        return $this->method('history', compact('channel', 'count', 'latest', 'oldest', 'inclusive'));
+        return $this->method('history', compact('channel', 'limit', 'latest', 'oldest', 'inclusive'));
     }
 
     /**

--- a/src/Vluzrmos/SlackApi/Methods/InstantMessage.php
+++ b/src/Vluzrmos/SlackApi/Methods/InstantMessage.php
@@ -27,16 +27,16 @@ class InstantMessage extends SlackMethod implements SlackInstantMessage
      * @see https://api.slack.com/methods/conversations.history
      *
      * @param string $channel Channel to fetch history for.
-     * @param int    $count Number of messages to return, between 1 and 1000.
+     * @param int    $limit Number of messages to return, between 1 and 1000.
      * @param string $latest End of time range of messages to include in results.
      * @param int|string    $oldest Start of time range of messages to include in results.
      * @param int    $inclusive Include messages with latest or oldest timestamp in results.
      *
      * @return array
      */
-    public function history($channel, $count = 100, $latest = null, $oldest = 0, $inclusive = 1)
+    public function history($channel, $limit = 100, $latest = null, $oldest = 0, $inclusive = 1)
     {
-        return $this->method('history', compact('channel', 'count', 'latest', 'oldest', 'inclusive'));
+        return $this->method('history', compact('channel', 'limit', 'latest', 'oldest', 'inclusive'));
     }
 
     /**


### PR DESCRIPTION
New parameter is limit, not count
https://api.slack.com/methods/conversations.history