### PR TITLE
Adding possibility to access other parameters from the channel call. 

### DIFF
--- a/src/Vluzrmos/SlackApi/Contracts/SlackChannel.php
+++ b/src/Vluzrmos/SlackApi/Contracts/SlackChannel.php
@@ -13,8 +13,8 @@ interface SlackChannel
     public function join($name);
     public function kick($channel, $user);
     public function leave($channel);
-    public function all($exclude_archived = 1);
-    public function lists($exclude_archived = 1);
+    public function all($exclude_archived = 1, $options =[]);
+    public function lists($exclude_archived = 1, $options =[]);
     public function mark($channel, $ts);
     public function rename($channel, $name);
     public function setPurpose($channel, $purpose);

--- a/src/Vluzrmos/SlackApi/Methods/Channel.php
+++ b/src/Vluzrmos/SlackApi/Methods/Channel.php
@@ -133,9 +133,9 @@ class Channel extends SlackMethod implements SlackChannel
      *
      * @return array
      */
-    public function all($exclude_archived = 1)
+    public function all($exclude_archived = 1, $options = [])
     {
-        return $this->method('list', compact('exclude_archived'));
+        return $this->method('list', array_merge(compact('exclude_archived'), $options));
     }
 
     /**
@@ -148,9 +148,9 @@ class Channel extends SlackMethod implements SlackChannel
      *
      * @return array
      */
-    public function lists($exclude_archived = 1)
+    public function lists($exclude_archived = 1, $options = [])
     {
-        return $this->all($exclude_archived);
+        return $this->all($exclude_archived, $options);
     }
 
     /**

--- a/src/Vluzrmos/SlackApi/Methods/Channel.php
+++ b/src/Vluzrmos/SlackApi/Methods/Channel.php
@@ -130,7 +130,7 @@ class Channel extends SlackMethod implements SlackChannel
      * @see https://api.slack.com/methods/conversations.list
      *
      * @param int $exclude_archived Don't return archived conversations.
-     *
+     * @param array $options ['limit' = 100, 'cursor' => "dXNlcjpVMDYxTkZUVDI=", types => "public_channel", "team_id"=>,T1234567890 ]
      * @return array
      */
     public function all($exclude_archived = 1, $options = [])
@@ -145,6 +145,7 @@ class Channel extends SlackMethod implements SlackChannel
      * @see https://api.slack.com/methods/conversations.list
      *
      * @param int $exclude_archived Don't return archived conversations.
+     * @param array $options ['limit' = 100, 'cursor' => "dXNlcjpVMDYxTkZUVDI=", types => "public_channel", "team_id"=>,T1234567890 ]
      *
      * @return array
      */


### PR DESCRIPTION
At the moment it's not possible to fetch more than 100 channels. If you want more you can add to the limit or use a cursor. By adding the possibility to add extra options we can use both with minimal effort. 