### PR TITLE
'blocks' outside of 'attachments' might be an array, but must be JSON

### DIFF
--- a/src/Vluzrmos/SlackApi/SlackApi.php
+++ b/src/Vluzrmos/SlackApi/SlackApi.php
@@ -242,6 +242,10 @@ class SlackApi implements Contract
             ]
         ];
 
+        if (isset($parameters['blocks']) && is_array($parameters['blocks'])) {
+            $parameters['blocks'] = json_encode($parameters['blocks']);
+        }
+
         if (isset($parameters['attachments']) && is_array($parameters['attachments'])) {
             $parameters['attachments'] = json_encode($parameters['attachments']);
         }


### PR DESCRIPTION
Since `blocks` can also be placed outside of `attachments`, I've added the statement "encode into JSON if an array is given (i.e., if JSON is not given)" as is done for `blocks` inside of `attachments`.
https://api.slack.com/messaging/composing/layouts#add_blocks_array